### PR TITLE
feat: meta-analytics to evaluate coil usefulness

### DIFF
--- a/docs/adr/002-meta-analytics.md
+++ b/docs/adr/002-meta-analytics.md
@@ -1,0 +1,48 @@
+# ADR-002: Meta-Analytics for Coil Usefulness Evaluation
+
+**Status:** Accepted
+**Date:** 2026-02-18
+**Issue:** https://github.com/danwt/coil/issues/2
+
+## Context
+
+After shipping v1, all memories sat at the default 0.5 utility score. Coil was effectively write-only — memories were stored but there was no signal indicating whether the tool was being used or helping. The question "should we keep using coil?" had no data-driven answer.
+
+## Decision
+
+Add lightweight event logging to the SQLite DB and a `coil_weekly_report` tool that produces a signal (HEALTHY / MARGINAL / NO_DATA) answerable on a weekly cadence.
+
+### Event table
+
+A single `events` table records: `session` (SessionStart), `store`, `retrieve`, `feedback_useful`, `feedback_not_useful`. No session IDs or session boundaries — aggregate counts over a time window are sufficient for the evaluation question.
+
+### Two key metrics
+
+1. **Retrievals per session** — if agents never query coil, it cannot help. Target: ≥2/session.
+2. **Yield rate** — `feedback_useful / total_feedback`. Measures quality of what is stored. Target: ≥20%.
+
+### Signal thresholds
+
+| Signal | Condition |
+|---|---|
+| NO_DATA | sessions=0 OR retrievals=0 |
+| MARGINAL | rate<2 OR yield<20% OR no feedback at all |
+| HEALTHY | rate≥2 AND yield≥20% |
+
+### Session logging
+
+The `SessionStart` hook (`hooks/context.ts`) logs a `session` event each time it runs. This is the natural proxy for "a session started in a coil-aware project".
+
+## Alternatives Considered
+
+**Session IDs tying events together** — would allow per-session breakdowns but requires passing session context through every tool call. Overkill for the evaluation question.
+
+**Separate analytics DB** — unnecessary, same SQLite file is simpler and keeps data co-located.
+
+**Embedding-based quality signals** — too complex for v1. Simple counts are sufficient.
+
+## Consequences
+
+- `events` table grows unboundedly (acceptable — event rows are tiny, ~100 bytes each; a year of heavy use ≈ a few MB)
+- Session count only tracks projects with SessionStart hooks. Other MCP clients get retrieval/feedback events but not session events.
+- Yield rate is only meaningful if agents consistently call `coil_feedback`. Documented as a behavioral requirement in the skill prompt.

--- a/hooks/context.ts
+++ b/hooks/context.ts
@@ -19,6 +19,7 @@ if (!existsSync(DB_PATH)) {
 
 const store = new MemoryStore(DB_PATH);
 const project = detectProject();
+store.logSession(project);
 const ctx = store.context(project);
 store.close();
 

--- a/plugin/skills/coil/SKILL.md
+++ b/plugin/skills/coil/SKILL.md
@@ -7,9 +7,9 @@ description: >
   asks to store or recall something. Also triggers on "/coil status",
   "/coil search", "/coil forget". Do NOT use for ephemeral conversation
   context that won't matter next session.
-argument-hint: [status|search <query>|forget <id>]
+argument-hint: [status|search <query>|forget <id>|weekly]
 user-invocable: true
-allowed-tools: mcp__coil__coil_status, mcp__coil__coil_search, mcp__coil__coil_query, mcp__coil__coil_forget, mcp__coil__coil_store, mcp__coil__coil_feedback, mcp__coil__coil_relate, mcp__coil__coil_export
+allowed-tools: mcp__coil__coil_status, mcp__coil__coil_search, mcp__coil__coil_query, mcp__coil__coil_forget, mcp__coil__coil_store, mcp__coil__coil_feedback, mcp__coil__coil_relate, mcp__coil__coil_export, mcp__coil__coil_weekly_report
 ---
 
 # Coil Memory Manager
@@ -19,6 +19,7 @@ allowed-tools: mcp__coil__coil_status, mcp__coil__coil_search, mcp__coil__coil_q
 - `/coil status` — memory overview: counts by kind, projects, top utility items
 - `/coil search <query>` — full-text search across all memories
 - `/coil forget <id>` — hard delete a memory by ID
+- `/coil weekly` — meta-analytics report: was coil useful this week?
 
 ## Storing Memories
 
@@ -44,8 +45,13 @@ See [references/usage.md](references/usage.md) for filter syntax, sort options, 
 
 ## Feedback and Linking
 
-- Call `coil_feedback(id, useful=true)` after using a retrieved memory. Memories without positive feedback decay toward 0.1.
+**REQUIRED:** After retrieving and using any memory, you MUST call `coil_feedback(id, useful=true/false)` before ending the session. This is not optional — without it the weekly analytics signal is meaningless and coil cannot evaluate its own usefulness.
+
 - Call `coil_relate(id, related_id)` to link related memories (e.g. an error and the decision that fixed it).
+
+## Meta-Analytics
+
+- `coil_weekly_report` — was coil useful this week? Returns HEALTHY / MARGINAL / NO_DATA signal based on retrievals-per-session (target ≥2) and feedback yield rate (target ≥20%). Run weekly to decide whether to keep using coil.
 
 ## Debugging
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ function formatSection(heading: string, items: Memory[]): string | null {
 
 const server = new McpServer({
   name: "coil",
-  version: "0.1.0",
+  version: "0.2.0",
 });
 
 server.registerTool("coil_store", {
@@ -121,6 +121,44 @@ server.registerTool("coil_status", {
   return textResult(
     `Coil Memory Store\n${"─".repeat(18)}\nTotal: ${s.total}\n\nBy kind:\n${kindLines}\n\nBy project:\n${projLines}\n\nTop utility:\n  ${topLines}`,
   );
+});
+
+server.registerTool("coil_weekly_report", {
+  description:
+    "Weekly meta-analytics: was coil actually useful this week? Shows session count, retrieval rate, feedback yield, and an overall signal (HEALTHY / MARGINAL / NO_DATA).",
+  inputSchema: {
+    weeks: z.number().int().min(1).max(12).optional().default(1).describe("Number of weeks to report on"),
+  },
+}, (args) => {
+  const r = store.weeklyReport(args.weeks ?? 1);
+
+  const since = new Date(Date.now() - r.periodDays * 24 * 60 * 60 * 1000);
+  const dateStr = since.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+  const today = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+
+  const yieldStr = r.yieldRate !== null ? `${(r.yieldRate * 100).toFixed(0)}%` : 'n/a';
+  const rateStr = r.retrievalsPerSession !== null ? `${r.retrievalsPerSession.toFixed(1)}/session` : 'n/a';
+  const feedbackStr = `${r.feedbackUseful} useful, ${r.feedbackNotUseful} not`;
+
+  const lines = [
+    `Coil Meta Report: ${dateStr} – ${today}`,
+    '─'.repeat(40),
+    `Sessions tracked:     ${r.sessions}`,
+    `Retrievals total:     ${r.retrievals}   (${rateStr})`,
+    `New memories stored:  ${r.stores}`,
+    `Feedback given:       ${r.feedbackUseful + r.feedbackNotUseful}   (${feedbackStr})`,
+    `Yield rate:           ${yieldStr}`,
+    '',
+    `Signal: ${r.signal}`,
+  ];
+
+  if (r.signalReasons.length > 0) {
+    for (const reason of r.signalReasons) {
+      lines.push(`  → ${reason}`);
+    }
+  }
+
+  return textResult(lines.join('\n'));
 });
 
 server.registerTool("coil_context", {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -268,3 +268,68 @@ describe("export/import", () => {
     newStore.close();
   });
 });
+
+describe("events and weekly report", () => {
+  it("logs session events", () => {
+    store.logSession("myproj");
+    const report = store.weeklyReport();
+    expect(report.sessions).toBe(1);
+  });
+
+  it("logs store events", () => {
+    store.store("decision", "proj", "Use RLS", []);
+    const report = store.weeklyReport();
+    expect(report.stores).toBe(1);
+  });
+
+  it("logs retrieve events on query", () => {
+    store.store("decision", "proj", "D1", []);
+    store.store("decision", "proj", "D2", []);
+    store.query();
+    const report = store.weeklyReport();
+    expect(report.retrievals).toBe(1);
+  });
+
+  it("logs feedback events", () => {
+    const m = store.store("error", "proj", "Bug", []);
+    store.query();
+    store.feedback(m.id, true);
+    store.feedback(m.id, false);
+    const report = store.weeklyReport();
+    expect(report.feedbackUseful).toBe(1);
+    expect(report.feedbackNotUseful).toBe(1);
+  });
+
+  it("returns NO_DATA with no sessions", () => {
+    const report = store.weeklyReport();
+    expect(report.signal).toBe("NO_DATA");
+  });
+
+  it("returns HEALTHY with good metrics", () => {
+    store.logSession("proj");
+    store.logSession("proj");
+    const m1 = store.store("decision", "proj", "D1", []);
+    const m2 = store.store("error", "proj", "E1", []);
+    store.query();
+    store.query();
+    store.query();
+    store.query();
+    store.query();
+    store.feedback(m1.id, true);
+    store.feedback(m2.id, true);
+    const report = store.weeklyReport();
+    expect(report.signal).toBe("HEALTHY");
+  });
+
+  it("computes correct yield rate", () => {
+    store.logSession("proj");
+    const m = store.store("decision", "proj", "D1", []);
+    store.query();
+    store.query();
+    store.query();
+    store.feedback(m.id, true);
+    store.feedback(m.id, false);
+    const report = store.weeklyReport();
+    expect(report.yieldRate).toBe(0.5);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,6 +39,18 @@ CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
   tags,
   tokenize='porter'
 );
+
+CREATE TABLE IF NOT EXISTS events (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts        TEXT NOT NULL,
+  kind      TEXT NOT NULL,
+  project   TEXT NOT NULL,
+  memory_id TEXT,
+  detail    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
+CREATE INDEX IF NOT EXISTS idx_events_kind ON events(kind);
 `;
 
 const SORT_MAP: Record<SortOption, string> = {
@@ -87,6 +99,8 @@ export class MemoryStore {
         .run(id, content, tagsJson);
     });
     tx();
+
+    this.logEvent('store', project, id);
 
     return {
       id,
@@ -172,6 +186,8 @@ export class MemoryStore {
         .run(now, row.id);
     }
 
+    this.logEvent('retrieve', (filter as any)?.project ?? 'unknown', undefined, String(rows.length));
+
     return rows.map(rowToMemory);
   }
 
@@ -198,6 +214,9 @@ export class MemoryStore {
                  ORDER BY rank`;
 
     const rows = this.db.prepare(sql).all(...params) as MemoryRow[];
+
+    this.logEvent('retrieve', 'unknown', undefined, String(rows.length));
+
     return rows.map(rowToMemory);
   }
 
@@ -210,7 +229,9 @@ export class MemoryStore {
         .run(id);
     }
     this.recalculateUtility(id);
-    return this.get(id);
+    const memory = this.get(id);
+    this.logEvent(useful ? 'feedback_useful' : 'feedback_not_useful', memory?.project ?? 'unknown', id);
+    return memory;
   }
 
   relate(id: string, relatedId: string): boolean {
@@ -361,8 +382,86 @@ export class MemoryStore {
     return count;
   }
 
+  logSession(project: string): void {
+    this.logEvent('session', project);
+  }
+
+  weeklyReport(weeks: number = 1): {
+    periodDays: number;
+    sessions: number;
+    retrievals: number;
+    stores: number;
+    feedbackUseful: number;
+    feedbackNotUseful: number;
+    yieldRate: number | null;
+    retrievalsPerSession: number | null;
+    signal: 'HEALTHY' | 'MARGINAL' | 'NO_DATA';
+    signalReasons: string[];
+  } {
+    const since = new Date(Date.now() - weeks * 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    const count = (kind: string): number => {
+      const row = this.db
+        .prepare(`SELECT COUNT(*) as c FROM events WHERE kind = ? AND ts >= ?`)
+        .get(kind, since) as { c: number };
+      return row.c;
+    };
+
+    const sessions = count('session');
+    const retrievals = count('retrieve');
+    const stores = count('store');
+    const feedbackUseful = count('feedback_useful');
+    const feedbackNotUseful = count('feedback_not_useful');
+
+    const totalFeedback = feedbackUseful + feedbackNotUseful;
+    const yieldRate = totalFeedback > 0 ? feedbackUseful / totalFeedback : null;
+    const retrievalsPerSession = sessions > 0 ? retrievals / sessions : null;
+
+    const signalReasons: string[] = [];
+    let signal: 'HEALTHY' | 'MARGINAL' | 'NO_DATA';
+
+    if (sessions === 0 || retrievals === 0) {
+      signal = 'NO_DATA';
+      if (sessions === 0) signalReasons.push('No sessions logged — SessionStart hook may not be running');
+      if (retrievals === 0) signalReasons.push('No retrievals recorded — coil is not being queried');
+    } else {
+      const issues: string[] = [];
+      if (retrievalsPerSession !== null && retrievalsPerSession < 2) {
+        issues.push(`retrieval rate low: ${retrievalsPerSession.toFixed(1)}/session (target ≥2)`);
+      }
+      if (yieldRate !== null && yieldRate < 0.2) {
+        issues.push(`yield rate low: ${(yieldRate * 100).toFixed(0)}% (target ≥20%)`);
+      }
+      if (yieldRate === null) {
+        issues.push('no feedback calls recorded — agents must call coil_feedback after using memories');
+      }
+      if (issues.length > 0) {
+        signal = 'MARGINAL';
+        signalReasons.push(...issues);
+      } else {
+        signal = 'HEALTHY';
+      }
+    }
+
+    return { periodDays: weeks * 7, sessions, retrievals, stores, feedbackUseful, feedbackNotUseful, yieldRate, retrievalsPerSession, signal, signalReasons };
+  }
+
   close(): void {
     this.db.close();
+  }
+
+  private logEvent(
+    kind: string,
+    project: string,
+    memoryId?: string,
+    detail?: string,
+  ): void {
+    const ts = new Date().toISOString();
+    this.db
+      .prepare(
+        `INSERT INTO events (ts, kind, project, memory_id, detail) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(ts, kind, project, memoryId ?? null, detail ?? null);
   }
 
   private recalculateUtility(id: string): void {


### PR DESCRIPTION
## Summary

Closes #2.

- Adds an `events` SQLite table tracking `session`, `store`, `retrieve`, `feedback_useful`, and `feedback_not_useful` events, written inline from existing `MemoryStore` methods
- Adds `coil_weekly_report` MCP tool that emits a `HEALTHY / MARGINAL / NO_DATA` signal based on retrievals-per-session (target ≥2) and feedback yield rate (target ≥20%)
- `hooks/context.ts` (SessionStart) now calls `logSession()` so session count acts as the denominator for retrieval rate

## Test plan

- [ ] `bun test` passes (30 tests, 0 failures)
- [ ] Call `coil_weekly_report` with no data — expect `NO_DATA` signal
- [ ] Run a few sessions with queries and feedback — expect signal to progress to `HEALTHY`
- [ ] Verify `events` table rows appear in the SQLite DB after a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)